### PR TITLE
Fixed the repl.it url

### DIFF
--- a/src/foreclojure/template.clj
+++ b/src/foreclojure/template.clj
@@ -42,7 +42,7 @@
                 ["/problems" "Problem List"]
                 ["/users" "Top Users"]
                 ["/directions" "Help"]
-                ["http://try-clojure.org" "REPL" true]
+                ["https://repl.it/languages/clojure" "REPL.it" true]
                 ["http://clojuredocs.org" "Docs" true]]]
            [:a.menu (assoc (when tabbed {:target "_blank"})
                       :href link)


### PR DESCRIPTION
- Old repl domain not valid now
- Replaced with repl.it clojure url